### PR TITLE
input field improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,7 +269,7 @@
 				<form onsubmit="return false;" method="post">
 				<div class="fill right-header-paragraph">
 					<span class="bitcoin fill-fixed">₿</span>
-					<input class="fill-use-remaining text-box" type="text" id="address" value="send.some@satsto.me"/>
+					<input class="fill-use-remaining text-box" type="text" id="address" value="send.some@satsto.me" onfocus="if (this.value === 'send.some@satsto.me') this.value = '';" onblur="if (this.value === '') this.value = 'send.some@satsto.me';" onkeydown="if(event.which == 13 || event.keyCode == 13) lookup_domain();" />
 					<!-- SVG from bootstrap icons, Copyright (c) 2019-2024 The Bootstrap Authors, MIT License -->
 					<svg onclick="lookup_domain()" id="paybutton" xmlns="http://www.w3.org/2000/svg" fill="white" class="go-button go-button-disabled fill-fixed" viewBox="0 0 16 16">
 						<path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0M4.5 7.5a.5.5 0 0 0 0 1h5.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3a.5.5 0 0 0 0-.708l-3-3a.5.5 0 1 0-.708.708L10.293 7.5z"/>


### PR DESCRIPTION
Kind of annoying to have to triple-click / back out the default value, so this makes it so when the user clicks into the input field the default value is cleared. Still preserves the original behaviour where the user can click submit directly and the default value will be used to submit the form.

Also makes it so when the user is tying in an entry, they can click enter to submit the form (instead of needing to click the SVG button).